### PR TITLE
Add failing tests for fs.watch

### DIFF
--- a/test/watch.js
+++ b/test/watch.js
@@ -1,0 +1,31 @@
+var test = require('./helpers/test');
+
+test('watch before creating file', function(fs, t) {
+	t.plan(3);
+
+	fs.watch('/test', function() {
+		t.ok(true, 'watch handler called');
+	});
+
+	fs.writeFile('/test', new Buffer(1), function() {
+		fs.truncate('/test', 10000, function(err) {
+			fs.unlink('/test');
+		});
+	});
+});
+
+test('watch on existing file', function(fs, t) {
+	t.plan(3);
+
+	fs.writeFile('/test', new Buffer(1), function() {
+		fs.watch('/test', function() {
+			t.ok(true, 'watch handler called');
+		});
+		fs.writeFile('/test', new Buffer(1), function() {
+			fs.truncate('/test', 10000, function(err) {
+				fs.unlink('/test');
+			});
+		});
+	})
+
+});


### PR DESCRIPTION
`fs.watchFile` works, `fs.watch` does not

though looking at the source it seems like it should work  `¯\_(シ)_/¯`
